### PR TITLE
Update .gitignore to exclude error screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 target/
 .idea/
 *.iml
-vaadin-crud-flow-integration-tests/error-screenshots/
+vaadin-rich-text-editor-flow-integration-tests/error-screenshots/
 **/build-tools/node
 **/build-tools/node_modules
 **/package-lock.json


### PR DESCRIPTION
Fixing the CRUD leftover in `.gitignore`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor-flow/19)
<!-- Reviewable:end -->
