### PR TITLE
Get rid of HtmlValueChangeEvent and addHtmlValueChangeListener

### DIFF
--- a/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/GeneratedVaadinRichTextEditor.java
+++ b/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/GeneratedVaadinRichTextEditor.java
@@ -341,37 +341,6 @@ public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRic
                 (ComponentEventListener) listener);
     }
 
-    public static class HtmlValueChangeEvent<R extends GeneratedVaadinRichTextEditor<R, ?>>
-            extends ComponentEvent<R> {
-        private final String htmlValue;
-
-        public HtmlValueChangeEvent(R source, boolean fromClient) {
-            super(source, fromClient);
-            this.htmlValue = source.getHtmlValueString();
-        }
-
-        public String getHtmlValue() {
-            return htmlValue;
-        }
-    }
-
-    /**
-     * Adds a listener for {@code html-value-changed} events fired by the
-     * webcomponent.
-     *
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    protected Registration addHtmlValueChangeListener(
-            ComponentEventListener<HtmlValueChangeEvent<R>> listener) {
-        return getElement()
-                .addPropertyChangeListener("htmlValue",
-                        event -> listener.onComponentEvent(
-                                new HtmlValueChangeEvent<R>((R) this,
-                                        event.isUserOriginated())));
-    }
-
     /**
      * Constructs a new GeneratedVaadinRichTextEditor component with the given
      * arguments.


### PR DESCRIPTION
It was decided, that users can get the proper sanitised `htmlValue` from the component on `ValueChangeListener`, so we can drop `HtmlValueChangeEvent` and `addHtmlValueChangeListener`.

Fixes #13

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor-flow/27)
<!-- Reviewable:end -->
