### PR TITLE
Add AsHtml for accessing htmlValue with the binder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<artifactId>vaadin-rich-text-editor-flow-root</artifactId>
 	<packaging>pom</packaging>
-	<version>2.0-SNAPSHOT</version>
+	<version>2.1-SNAPSHOT</version>
 	<name>Vaadin Rich Text Editor Root</name>
 	<inceptionYear>2018</inceptionYear>
 	<organization>

--- a/vaadin-rich-text-editor-flow-demo/pom.xml
+++ b/vaadin-rich-text-editor-flow-demo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-root</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-rich-text-editor-flow-demo</artifactId>

--- a/vaadin-rich-text-editor-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-rich-text-editor-flow-integration-tests/pom-bower-mode.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-root</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
     <artifactId>vaadin-rich-text-editor-integration-tests-bower-mode</artifactId>
 

--- a/vaadin-rich-text-editor-flow-integration-tests/pom.xml
+++ b/vaadin-rich-text-editor-flow-integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-root</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-rich-text-editor-integration-tests</artifactId>

--- a/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
@@ -199,16 +199,18 @@ public class MainView extends VerticalLayout {
         // Create the action buttons
         Button save = new Button("Save");
         Button reset = new Button("Reset");
+        Button setBeanHtmlValue = new Button("Set bean html value");
         Button getValueButton = new Button("Get value");
         getValueButton.setId("get-html-binder-rte-value");
         getValueButton.addClickListener(event -> {
             String value = asHtml.getValue();
-            valuePanel.setText(value);
+            String webcomponentValue = rte.getElement().getProperty("htmlValue");
+            valuePanel.setText(value + ' ' + webcomponentValue);
         });
 
         // Button bar
         HorizontalLayout actions = new HorizontalLayout();
-        actions.add(save, reset, getValueButton);
+        actions.add(save, reset, getValueButton, setBeanHtmlValue);
         save.getStyle().set("marginRight", "10px");
 
         SerializablePredicate<String> htmlValuePredicate = value -> !asHtml
@@ -241,9 +243,14 @@ public class MainView extends VerticalLayout {
             binder.readBean(null);
             infoPanel.setText("");
         });
+        setBeanHtmlValue.addClickListener(event -> {
+            entryBeingEdited.setHtmlValue("<p><b>Foo</b></p>");
+            binder.readBean(entryBeingEdited);
+        });
 
         infoPanel.setId("html-binder-info");
         save.setId("html-binder-save");
+        setBeanHtmlValue.setId("html-binder-set-bean-value");
         reset.setId("html-binder-reset");
 
         add(actions, infoPanel, valuePanel);

--- a/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
@@ -40,6 +40,10 @@ public class MainView extends VerticalLayout {
         setValueButton.setId("setValue");
         setValueButton.addClickListener(event -> rte.setValue("[{\"insert\":\"Foo\"}]"));
 
+        Button setHtmlValueButton = new Button("Set htmlValue");
+        setHtmlValueButton.setId("setHtmlValue");
+        setHtmlValueButton.addClickListener(event -> rte.setHtmlValue("<h3><i>Foo</i>Bar</h3>"));
+
         Button getValueButton = new Button("Get value");
         getValueButton.setId("getValue");
         getValueButton.addClickListener(event -> {
@@ -71,7 +75,7 @@ public class MainView extends VerticalLayout {
             }
         });
 
-        add(rte, setValueButton, getValueButton, getHtmlValueButton, setI18n, getI18n, valuePanel, htmlValuePanel, i18nPanel);
+        add(rte, setValueButton, setHtmlValueButton, getValueButton, getHtmlValueButton, setI18n, getI18n, valuePanel, htmlValuePanel, i18nPanel);
 
         createRichTextEditorWithBinder();
 

--- a/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
@@ -11,7 +11,6 @@ import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.binder.Binder.Binding;
 import com.vaadin.flow.data.binder.BinderValidationStatus;
 import com.vaadin.flow.data.binder.BindingValidationStatus;
-import com.vaadin.flow.data.binder.ValidationException;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.router.Route;
@@ -42,10 +41,6 @@ public class MainView extends VerticalLayout {
         Button setValueButton = new Button("Set value");
         setValueButton.setId("setValue");
         setValueButton.addClickListener(event -> rte.setValue("[{\"insert\":\"Foo\"}]"));
-
-        Button setHtmlValueAsynchronouslyButton = new Button("Set htmlValue asynchronously");
-        setHtmlValueAsynchronouslyButton.setId("setHtmlValueAsynchronously");
-        setHtmlValueAsynchronouslyButton.addClickListener(event -> rte.setHtmlValueAsynchronously("<h3><i>Foo</i>Bar</h3>"));
 
         Button getValueButton = new Button("Get value");
         getValueButton.setId("getValue");
@@ -78,7 +73,7 @@ public class MainView extends VerticalLayout {
             }
         });
 
-        add(rte, setValueButton, setHtmlValueAsynchronouslyButton, getValueButton, getHtmlValueButton, setI18n, getI18n, valuePanel, htmlValuePanel, i18nPanel);
+        add(rte, setValueButton, getValueButton, getHtmlValueButton, setI18n, getI18n, valuePanel, htmlValuePanel, i18nPanel);
 
         createRichTextEditorWithBinder();
 
@@ -154,7 +149,7 @@ public class MainView extends VerticalLayout {
                         "Delta value should contain something")
                 .bind(Entry::getDeltaValue, Entry::setDeltaValue);
 
-        // First name and last name are required fields
+        // Editor is a required field
         rteWithBinder.setRequiredIndicatorVisible(true);
 
         // Click listeners for the buttons
@@ -185,50 +180,73 @@ public class MainView extends VerticalLayout {
         add(rteWithBinder, actions, infoPanel, valuePanel);
     }
 
-    private class Product implements Serializable {
-        private int id;
-        private String description;
-
-        public Product(String description) {
-            this.description = description;
-        }
-
-        public String getDescription() {
-            return description;
-        }
-
-        public void setDescription(String description) {
-            this.description = description;
-        }
-    }
-
     private void createRichTextEditorWithHtmlBinder() {
         RichTextEditor rte = new RichTextEditor();
+        rte.setId("html-rte");
+        add(rte);
+
         HasValue<ValueChangeEvent<String>, String> asHtml = rte.asHtml();
-        asHtml.setValue("<p>foo</p><b>bar</b>");
 
-        Binder<Product> binder = new Binder<>(Product.class);
-        binder.forField(rte.asHtml())
-                .bind(Product::getDescription, Product::setDescription);
+        Div valuePanel = new Div();
+        valuePanel.setId("html-binder-value-panel");
 
-        Product product = new Product("<p><b>Some description</b></p>");
-        binder.readBean(product);
+        Div infoPanel = new Div();
+        Binder<HtmlEntry> binder = new Binder<>();
 
-        Button saveButton = new Button("Save",
-                event -> {
-                    try {
-                        binder.writeBean(product);
-                    } catch (ValidationException e) {
-                        System.out.println(e);
-                    }
-                });
+        // The object that will be edited
+        HtmlEntry entryBeingEdited = new HtmlEntry();
 
-        Button resetButton = new Button("Reset",
-                event -> binder.readBean(product));
+        // Create the action buttons
+        Button save = new Button("Save");
+        Button reset = new Button("Reset");
+        Button getValueButton = new Button("Get value");
+        getValueButton.setId("get-html-binder-rte-value");
+        getValueButton.addClickListener(event -> {
+            String value = asHtml.getValue();
+            valuePanel.setText(value);
+        });
 
-        asHtml.addValueChangeListener(event -> valuePanel.setText(product.toString()));
+        // Button bar
+        HorizontalLayout actions = new HorizontalLayout();
+        actions.add(save, reset, getValueButton);
+        save.getStyle().set("marginRight", "10px");
 
-        add(rte, saveButton, resetButton);
+        SerializablePredicate<String> htmlValuePredicate = value -> !asHtml
+                .getValue().trim().isEmpty();
+
+        Binding<HtmlEntry, String> asHtmlValueBinding = binder.forField(asHtml)
+                .withValidator(htmlValuePredicate,
+                        "html value should contain something")
+                .bind(HtmlEntry::getHtmlValue, HtmlEntry::setHtmlValue);
+
+        // Editor is a required field
+        asHtml.setRequiredIndicatorVisible(true);
+
+        // Click listeners for the buttons
+        save.addClickListener(event -> {
+            if (binder.writeBeanIfValid(entryBeingEdited)) {
+                infoPanel.setText("Saved bean values: " + entryBeingEdited);
+            } else {
+                BinderValidationStatus<HtmlEntry> validate = binder.validate();
+                String errorText = validate.getFieldValidationStatuses()
+                        .stream().filter(BindingValidationStatus::isError)
+                        .map(BindingValidationStatus::getMessage)
+                        .map(Optional::get).distinct()
+                        .collect(Collectors.joining(", "));
+                infoPanel.setText("There are errors: " + errorText);
+            }
+        });
+        reset.addClickListener(event -> {
+            // clear fields by setting null
+            binder.readBean(null);
+            infoPanel.setText("");
+        });
+
+        infoPanel.setId("html-binder-info");
+        save.setId("html-binder-save");
+        reset.setId("html-binder-reset");
+
+        add(actions, infoPanel, valuePanel);
     }
 
     /**
@@ -250,6 +268,29 @@ public class MainView extends VerticalLayout {
         public String toString() {
             return "Contact{" +
                     "deltaValue='" + deltaValue + '\'' +
+                    '}';
+        }
+    }
+
+    /**
+     * Example Bean for the Form with Html Binder.
+     */
+    private static class HtmlEntry implements Serializable {
+
+        private String htmlValue = "";
+
+        public String getHtmlValue() {
+            return htmlValue;
+        }
+
+        public void setHtmlValue(String htmlValue) {
+            this.htmlValue = htmlValue;
+        }
+
+        @Override
+        public String toString() {
+            return "Contact{" +
+                    "htmlValue='" + htmlValue + '\'' +
                     '}';
         }
     }

--- a/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
@@ -40,9 +40,9 @@ public class MainView extends VerticalLayout {
         setValueButton.setId("setValue");
         setValueButton.addClickListener(event -> rte.setValue("[{\"insert\":\"Foo\"}]"));
 
-        Button setHtmlValueButton = new Button("Set htmlValue");
-        setHtmlValueButton.setId("setHtmlValue");
-        setHtmlValueButton.addClickListener(event -> rte.setHtmlValue("<h3><i>Foo</i>Bar</h3>"));
+        Button setHtmlValueAsynchronouslyButton = new Button("Set htmlValue asynchronously");
+        setHtmlValueAsynchronouslyButton.setId("setHtmlValueAsynchronously");
+        setHtmlValueAsynchronouslyButton.addClickListener(event -> rte.setHtmlValueAsynchronously("<h3><i>Foo</i>Bar</h3>"));
 
         Button getValueButton = new Button("Get value");
         getValueButton.setId("getValue");
@@ -75,7 +75,7 @@ public class MainView extends VerticalLayout {
             }
         });
 
-        add(rte, setValueButton, setHtmlValueButton, getValueButton, getHtmlValueButton, setI18n, getI18n, valuePanel, htmlValuePanel, i18nPanel);
+        add(rte, setValueButton, setHtmlValueAsynchronouslyButton, getValueButton, getHtmlValueButton, setI18n, getI18n, valuePanel, htmlValuePanel, i18nPanel);
 
         createRichTextEditorWithBinder();
 

--- a/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/AbstractParallelTest.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/AbstractParallelTest.java
@@ -93,8 +93,16 @@ public abstract class AbstractParallelTest extends ParallelTest {
         return $("div").id("binder-info").getText();
     }
 
+    protected String getLastHtmlBinderInfoValue() {
+        return $("div").id("html-binder-info").getText();
+    }
+
     protected String getLastRteBinderValue() {
         return $("div").id("binder-value-panel").getText();
+    }
+
+    protected String getLastRteHtmlBinderValue() {
+        return $("div").id("html-binder-value-panel").getText();
     }
 
     protected String getLastRteTemplateValue() {

--- a/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/BasicUseIT.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/BasicUseIT.java
@@ -66,6 +66,21 @@ public class BasicUseIT extends AbstractParallelTest {
     }
 
     @Test
+    public void setHtmlValueCorrect() {
+        ButtonElement setHtmlValue = getTestButton("setHtmlValue");
+        setHtmlValue.click();
+
+        ButtonElement getValue = getTestButton("getValue");
+        ButtonElement getHtmlValue = getTestButton("getHtmlValue");
+        getValue.click();
+        getHtmlValue.click();
+
+        Assert.assertEquals("[{\"attributes\":{\"italic\":true},\"insert\":\"Foo\"}," +
+                "{\"insert\":\"Bar\"},{\"attributes\":{\"header\":3},\"insert\":\"\\n\"}]", getLastValue());
+        Assert.assertEquals("<h3><em>Foo</em>Bar</h3>", getLastHtmlValue());
+    }
+
+    @Test
     public void setAndGetI18nCorrect() {
         ButtonElement setI18n = getTestButton("setI18n");
         ButtonElement getI18n = getTestButton("getI18n");

--- a/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/BasicUseIT.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/BasicUseIT.java
@@ -66,9 +66,9 @@ public class BasicUseIT extends AbstractParallelTest {
     }
 
     @Test
-    public void setHtmlValueCorrect() {
-        ButtonElement setHtmlValue = getTestButton("setHtmlValue");
-        setHtmlValue.click();
+    public void setHtmlValueAsynchronouslyCorrect() {
+        ButtonElement setHtmlValueAsynchronously = getTestButton("setHtmlValueAsynchronously");
+        setHtmlValueAsynchronously.click();
 
         ButtonElement getValue = getTestButton("getValue");
         ButtonElement getHtmlValue = getTestButton("getHtmlValue");

--- a/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/BasicUseIT.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/BasicUseIT.java
@@ -66,21 +66,6 @@ public class BasicUseIT extends AbstractParallelTest {
     }
 
     @Test
-    public void setHtmlValueAsynchronouslyCorrect() {
-        ButtonElement setHtmlValueAsynchronously = getTestButton("setHtmlValueAsynchronously");
-        setHtmlValueAsynchronously.click();
-
-        ButtonElement getValue = getTestButton("getValue");
-        ButtonElement getHtmlValue = getTestButton("getHtmlValue");
-        getValue.click();
-        getHtmlValue.click();
-
-        Assert.assertEquals("[{\"attributes\":{\"italic\":true},\"insert\":\"Foo\"}," +
-                "{\"insert\":\"Bar\"},{\"attributes\":{\"header\":3},\"insert\":\"\\n\"}]", getLastValue());
-        Assert.assertEquals("<h3><em>Foo</em>Bar</h3>", getLastHtmlValue());
-    }
-
-    @Test
     public void setAndGetI18nCorrect() {
         ButtonElement setI18n = getTestButton("setI18n");
         ButtonElement getI18n = getTestButton("getI18n");
@@ -124,6 +109,42 @@ public class BasicUseIT extends AbstractParallelTest {
 
         getValue.click();
         Assert.assertEquals("", getLastRteBinderValue());
+    }
+
+    // asHtml with Binder
+    @Test
+    public void useBinderWithRichTextEditorAsHtml() {
+        WebElement info = findElement(By.id("html-binder-info"));
+        ButtonElement save = getTestButton("html-binder-save");
+        ButtonElement reset = getTestButton("html-binder-reset");
+        ButtonElement getValue = getTestButton("get-html-binder-rte-value");
+        save.click();
+
+        // Empty rte validation: there is an error
+        waitUntil(
+                driver -> "There are errors: html value should contain something"
+                        .equals(getLastHtmlBinderInfoValue()));
+
+        RichTextEditorElement rte = $(RichTextEditorElement.class).id("html-rte");
+        TestBenchElement editor = rte.getEditor();
+        editor.setProperty("innerHTML", "<p>Foo</p>");
+
+        // Rte validation
+        waitUntil(driver -> {
+            rte.dispatchEvent("change");
+            save.click();
+            return info.getText().startsWith("Saved bean values");
+        });
+
+        Assert.assertTrue(getLastHtmlBinderInfoValue().contains("<p>Foo</p>"));
+
+        reset.click();
+
+        // Wait for everything to update.
+        waitUntil(driver -> info.getText().isEmpty());
+
+        getValue.click();
+        Assert.assertEquals("", getLastRteHtmlBinderValue());
     }
 
     @Test

--- a/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/BasicUseIT.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/test/java/com/vaadin/flow/component/richtexteditor/test/BasicUseIT.java
@@ -1,5 +1,8 @@
 package com.vaadin.flow.component.richtexteditor.test;
 
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.richtexteditor.testbench.RichTextEditorElement;
+import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -7,10 +10,6 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
-
-import com.vaadin.flow.component.button.testbench.ButtonElement;
-import com.vaadin.flow.component.richtexteditor.testbench.RichTextEditorElement;
-import com.vaadin.testbench.TestBenchElement;
 
 public class BasicUseIT extends AbstractParallelTest {
 
@@ -116,6 +115,7 @@ public class BasicUseIT extends AbstractParallelTest {
     public void useBinderWithRichTextEditorAsHtml() {
         WebElement info = findElement(By.id("html-binder-info"));
         ButtonElement save = getTestButton("html-binder-save");
+        ButtonElement setBeanHtmlValue = getTestButton("html-binder-set-bean-value");
         ButtonElement reset = getTestButton("html-binder-reset");
         ButtonElement getValue = getTestButton("get-html-binder-rte-value");
         save.click();
@@ -127,7 +127,7 @@ public class BasicUseIT extends AbstractParallelTest {
 
         RichTextEditorElement rte = $(RichTextEditorElement.class).id("html-rte");
         TestBenchElement editor = rte.getEditor();
-        editor.setProperty("innerHTML", "<p>Foo</p>");
+        editor.setProperty("innerHTML", "<p><b>Foo</b></p>");
 
         // Rte validation
         waitUntil(driver -> {
@@ -136,15 +136,24 @@ public class BasicUseIT extends AbstractParallelTest {
             return info.getText().startsWith("Saved bean values");
         });
 
-        Assert.assertTrue(getLastHtmlBinderInfoValue().contains("<p>Foo</p>"));
+        Assert.assertTrue(getLastHtmlBinderInfoValue().contains("<p><strong>Foo</strong></p>"));
 
         reset.click();
-
         // Wait for everything to update.
         waitUntil(driver -> info.getText().isEmpty());
 
-        getValue.click();
-        Assert.assertEquals("", getLastRteHtmlBinderValue());
+        setBeanHtmlValue.click();
+        waitUntil(driver -> {
+            getValue.click();
+            return getLastRteHtmlBinderValue().contains("<p><b>Foo</b></p> <p><strong>Foo</strong></p>");
+        });
+
+        reset.click();
+        // Wait for everything to update.
+        waitUntil(driver -> {
+            getValue.click();
+            return getLastRteHtmlBinderValue().equals("null <p><br></p>");
+        });
     }
 
     @Test

--- a/vaadin-rich-text-editor-flow-testbench/pom.xml
+++ b/vaadin-rich-text-editor-flow-testbench/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>vaadin-rich-text-editor-flow-root</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-rich-text-editor-testbench</artifactId>

--- a/vaadin-rich-text-editor-flow/pom.xml
+++ b/vaadin-rich-text-editor-flow/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.vaadin.webjar</groupId>
             <artifactId>vaadin-rich-text-editor</artifactId>
-            <version>1.0.4</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin.webjar</groupId>

--- a/vaadin-rich-text-editor-flow/pom.xml
+++ b/vaadin-rich-text-editor-flow/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-rich-text-editor-flow-root</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-rich-text-editor-flow</artifactId>

--- a/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/GeneratedVaadinRichTextEditor.java
+++ b/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/GeneratedVaadinRichTextEditor.java
@@ -211,7 +211,7 @@ import elemental.json.JsonArray;
         "WebComponent: Vaadin.RichTextEditorElement#1.0.0-alpha3",
         "Flow#1.2-SNAPSHOT" })
 @Tag("vaadin-rich-text-editor")
-@NpmPackage(value = "@vaadin/vaadin-rich-text-editor", version = "1.0.4")
+@NpmPackage(value = "@vaadin/vaadin-rich-text-editor", version = "1.1.0")
 @JsModule("@vaadin/vaadin-rich-text-editor/src/vaadin-rich-text-editor.js")
 @HtmlImport("frontend://bower_components/vaadin-rich-text-editor/src/vaadin-rich-text-editor.html")
 public abstract class GeneratedVaadinRichTextEditor<R extends GeneratedVaadinRichTextEditor<R, T>, T>

--- a/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -179,11 +179,13 @@ public class RichTextEditor extends GeneratedVaadinRichTextEditor<RichTextEditor
      * The HTML string is interpreted by
      * <a href="http://quilljs.com/docs/modules/clipboard/#matchers">Quill's Clipboard matchers</a>
      * on the client side, which may not produce the exactly input HTML.
+     * <p>
+     * Note: The value will be set asynchronously with client-server roundtrip.
      *
      * @param htmlValueString
      *            the HTML string
      */
-    public void setHtmlValue(String htmlValueString) {
+    public void setHtmlValueAsynchronously(String htmlValueString) {
         getElement().callFunction("dangerouslySetHtmlValue", sanitize(htmlValueString));
         getElement().executeJavaScript("$0.__debounceSetValue.flush();" +
                         "$0.$server.updateValue($0.value);", getElement());

--- a/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -175,6 +175,26 @@ public class RichTextEditor extends GeneratedVaadinRichTextEditor<RichTextEditor
     }
 
     /**
+     * Sets content represented by sanitized HTML string into the editor.
+     * The HTML string is interpreted by
+     * <a href="http://quilljs.com/docs/modules/clipboard/#matchers">Quill's Clipboard matchers</a>
+     * on the client side, which may not produce the exactly input HTML.
+     *
+     * @param htmlValueString
+     *            the HTML string
+     */
+    public void setHtmlValue(String htmlValueString) {
+        getElement().callFunction("dangerouslySetHtmlValue", sanitize(htmlValueString));
+        getElement().executeJavaScript("$0.__debounceSetValue.flush();" +
+                        "$0.$server.updateValue($0.value);", getElement());
+    }
+
+    @ClientCallable
+    private void updateValue(String value) {
+        setValue(value);
+    }
+
+    /**
      * Returns the current value of the text editor in <a href="https://github.com/quilljs/delta">Delta</a> format. By default, the empty
      * editor will return an empty string.
      *

--- a/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -771,7 +771,7 @@ public class RichTextEditor extends GeneratedVaadinRichTextEditor<RichTextEditor
             this.oldValue = getValue();
             this.value = value;
             setHtmlValueAsynchronously(value).then(result -> {
-                if (!oldValue.equals(value)) {
+                if (oldValue != null && !oldValue.equals(value)) {
                     fireEvent(createValueChange(oldValue, false));
                 }
             });

--- a/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
+++ b/vaadin-rich-text-editor-flow/src/test/java/com/vaadin/flow/component/richtexteditor/RichTextEditorTest.java
@@ -2,11 +2,12 @@ package com.vaadin.flow.component.richtexteditor;
 
 import static org.junit.Assert.assertEquals;
 
+import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import com.vaadin.flow.component.richtexteditor.RichTextEditor;
 
 /**
  * Tests for the {@link RichTextEditor}.
@@ -172,5 +173,34 @@ public class RichTextEditorTest {
     public void sanitizePreTag_preTagPersist() {
         RichTextEditor rte = new RichTextEditor();
         Assert.assertEquals("<pre>Foo</pre>", rte.sanitize("<pre>Foo</pre>"));
+    }
+
+    // asHtml
+
+    @Test
+    public void asHtml_setValue_getValue() {
+        HasValue<ValueChangeEvent<String>, String> rteAsHtml = new RichTextEditor().asHtml();
+        String htmlValue = "<strong>Foo</strong>";
+        rteAsHtml.setValue(htmlValue);
+        Assert.assertEquals("Should get the same value as it was set",
+                htmlValue, rteAsHtml.getValue());
+    }
+
+    @Test
+    public void asHtml_setReadOnly_rteIsReadonly() {
+        RichTextEditor rte = new RichTextEditor();
+        HasValue<ValueChangeEvent<String>, String> rteAsHtml = rte.asHtml();
+        rteAsHtml.setReadOnly(true);
+        Assert.assertTrue("Should be possible to set readonly on asHtml",
+                rte.isReadOnly());
+    }
+
+    @Test
+    public void asHtml_setRequiredIndicatorVisible_rteRequiredIndicatorVisible() {
+        RichTextEditor rte = new RichTextEditor();
+        HasValue<ValueChangeEvent<String>, String> rteAsHtml = rte.asHtml();
+        rteAsHtml.setRequiredIndicatorVisible(true);
+        Assert.assertTrue("Should be possible to set required indicator to be visible on asHtml",
+                rte.isRequiredIndicatorVisible());
     }
 }


### PR DESCRIPTION
Private `AsHtml` class is added which can be accessed via `asHtml`. It implements the `HasValue` interface, wraps the html value of the rte and listens to the `change` event. 
Thing worth mentioning: `AsHtml` fires server-side `ValueChangeEvent` when the html value is set on server side.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor-flow/66)
<!-- Reviewable:end -->
