### PR TITLE
Return the same instance of asHtml

### DIFF
--- a/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
+++ b/vaadin-rich-text-editor-flow-integration-tests/src/main/java/com/vaadin/flow/component/richtexteditor/examples/MainView.java
@@ -185,8 +185,6 @@ public class MainView extends VerticalLayout {
         rte.setId("html-rte");
         add(rte);
 
-        HasValue<ValueChangeEvent<String>, String> asHtml = rte.asHtml();
-
         Div valuePanel = new Div();
         valuePanel.setId("html-binder-value-panel");
 
@@ -203,7 +201,7 @@ public class MainView extends VerticalLayout {
         Button getValueButton = new Button("Get value");
         getValueButton.setId("get-html-binder-rte-value");
         getValueButton.addClickListener(event -> {
-            String value = asHtml.getValue();
+            String value = rte.asHtml().getValue();
             String webcomponentValue = rte.getElement().getProperty("htmlValue");
             valuePanel.setText(value + ' ' + webcomponentValue);
         });
@@ -213,16 +211,16 @@ public class MainView extends VerticalLayout {
         actions.add(save, reset, getValueButton, setBeanHtmlValue);
         save.getStyle().set("marginRight", "10px");
 
-        SerializablePredicate<String> htmlValuePredicate = value -> !asHtml
+        SerializablePredicate<String> htmlValuePredicate = value -> !rte.asHtml()
                 .getValue().trim().isEmpty();
 
-        Binding<HtmlEntry, String> asHtmlValueBinding = binder.forField(asHtml)
+        Binding<HtmlEntry, String> asHtmlValueBinding = binder.forField(rte.asHtml())
                 .withValidator(htmlValuePredicate,
                         "html value should contain something")
                 .bind(HtmlEntry::getHtmlValue, HtmlEntry::setHtmlValue);
 
         // Editor is a required field
-        asHtml.setRequiredIndicatorVisible(true);
+        rte.asHtml().setRequiredIndicatorVisible(true);
 
         // Click listeners for the buttons
         save.addClickListener(event -> {

--- a/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
+++ b/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java
@@ -44,6 +44,7 @@ public class RichTextEditor extends GeneratedVaadinRichTextEditor<RichTextEditor
 
     private ValueChangeMode currentMode;
     private RichTextEditorI18n i18n;
+    private AsHtml asHtml;
 
     /**
      * Gets the internationalization object previously set for this component.
@@ -741,7 +742,10 @@ public class RichTextEditor extends GeneratedVaadinRichTextEditor<RichTextEditor
      * @return an instance of {@code HasValue}
      */
     public HasValue<ValueChangeEvent<String>, String> asHtml() {
-        return new AsHtml(this);
+        if (asHtml == null) {
+            asHtml = new AsHtml(this);
+        }
+        return asHtml;
     }
 
     /**
@@ -755,6 +759,7 @@ public class RichTextEditor extends GeneratedVaadinRichTextEditor<RichTextEditor
 
         AsHtml(RichTextEditor rte) {
             this.rte = rte;
+            this.value = getHtmlValue();
             rte.addValueChangeListener(event -> {
                 if (event.isFromClient()) {
                    setValue(getHtmlValue(), false);


### PR DESCRIPTION
Connected https://github.com/vaadin/vaadin-rich-text-editor-flow/issues/75
Test page is updated to check the `rte.asHtml()` instead of a saved instance of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor-flow/76)
<!-- Reviewable:end -->
